### PR TITLE
file_name_in_send_file

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -173,6 +173,7 @@ class PyMongo(object):
             mimetype=fileobj.content_type,
             direct_passthrough=True,
         )
+        response.headers['Content-Disposition'] = 'attachment; filename={}'.format(filename)
         response.content_length = fileobj.length
         response.last_modified = fileobj.upload_date
         response.set_etag(fileobj.md5)


### PR DESCRIPTION
Some times file name not set in request. It is better to set it explicitly.