### PR TITLE
enable send_file function to send file via file_id(the hex str)

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -136,9 +136,6 @@ class PyMongo(object):
         Returns an instance of the :attr:`~flask.Flask.response_class`
         containing the named file, and implement conditional GET semantics
         (using :meth:`~werkzeug.wrappers.ETagResponseMixin.make_conditional`).
-        
-        You can either enter only filename or file_id of the file to return.
-        Please do not enter both.
 
         .. code-block:: python
 

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -169,6 +169,8 @@ class PyMongo(object):
                 fileobj = storage.get_version(filename=filename, version=version)
             elif file_id != None and filename == None:
                 fileobj = storage.get(ObjectId(file_id))
+            else:
+                raise TypeError("please enter either filename or file_id of the file you want to return")
         except NoFile:
             abort(404)
 

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -147,7 +147,8 @@ class PyMongo(object):
                 return mongo.send_file(filename)
 
         :param str filename: the filename of the file to return
-        :param str file_id: the file_id of the file to return. (only the hex str eg: '507f191e810c19729de860ea')
+        :param str file_id: the file_id of the file to return. (only the hex 
+           str eg: '507f191e810c19729de860ea')
         :param str base: the base name of the GridFS collections to use
         :param bool version: if positive, return the Nth revision of the file
            identified by filename; if negative, return the Nth most recent

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -170,7 +170,7 @@ class PyMongo(object):
             elif file_id != None and filename == None:
                 fileobj = storage.get(ObjectId(file_id))
             else:
-                raise TypeError("please enter either filename or file_id of the file you want to return")
+                abort(404)
         except NoFile:
             abort(404)
 


### PR DESCRIPTION
I was working on a streaming project, happened to use flask-pymongo, and found out that I needed to send file via file_id. And so I tweaked it a bit to send file via file id. Thought this might be helpful for other users. 