### PR TITLE
Add DriverInfo to MongoClient creation

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -39,9 +39,8 @@ try:
     from pymongo.driver_info import DriverInfo
 except ImportError:
     DriverInfo = None
-
-from flask_pymongo.helpers import BSONObjectIdConverter, JSONEncoder
 from flask_pymongo._version import __version__
+from flask_pymongo.helpers import BSONObjectIdConverter, JSONEncoder
 from flask_pymongo.wrappers import MongoClient
 
 DESCENDING = pymongo.DESCENDING

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -41,7 +41,6 @@ except ImportError:
     DriverInfo = None
 
 from flask_pymongo._version import __version__
-
 from flask_pymongo.helpers import BSONObjectIdConverter, JSONEncoder
 from flask_pymongo.wrappers import MongoClient
 

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -41,9 +41,8 @@ except ImportError:
     DriverInfo = None
 
 from flask_pymongo.helpers import BSONObjectIdConverter, JSONEncoder
-from flask_pymongo.wrappers import MongoClient
 from flask_pymongo._version import __version__
-
+from flask_pymongo.wrappers import MongoClient
 
 DESCENDING = pymongo.DESCENDING
 """Descending sort order."""

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -34,9 +34,15 @@ from gridfs import GridFS, NoFile
 from pymongo import uri_parser
 from werkzeug.wsgi import wrap_file
 import pymongo
+# DriverInfo was added in PyMongo 3.7
+try:
+    from pymongo.driver_info import DriverInfo
+except ImportError:
+    DriverInfo = None
 
 from flask_pymongo.helpers import BSONObjectIdConverter, JSONEncoder
 from flask_pymongo.wrappers import MongoClient
+from flask_pymongo._version import __version__
 
 
 DESCENDING = pymongo.DESCENDING
@@ -109,6 +115,8 @@ class PyMongo(object):
         # Try to delay connecting, in case the app is loaded before forking, per
         # http://api.mongodb.com/python/current/faq.html#is-pymongo-fork-safe
         kwargs.setdefault("connect", False)
+        if DriverInfo is not None:
+            kwargs.setdefault("driver", DriverInfo("Flask-PyMongo", __version__))
 
         self.cx = MongoClient(*args, **kwargs)
         if database_name:

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -39,7 +39,9 @@ try:
     from pymongo.driver_info import DriverInfo
 except ImportError:
     DriverInfo = None
+
 from flask_pymongo._version import __version__
+
 from flask_pymongo.helpers import BSONObjectIdConverter, JSONEncoder
 from flask_pymongo.wrappers import MongoClient
 


### PR DESCRIPTION
This PR will wrap the `MongoClient` creation with [`pymongo.driver_info.DriverInfo`](https://pymongo.readthedocs.io/en/stable/api/pymongo/driver_info.html#pymongo.driver_info.DriverInfo) which makes it easier to filter `mongod` logs for connections that originate from Flask-PyMongo.

For example:

> {"t":{"$date":"2024-06-03T16:10:26.686-04:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn225","msg":"client metadata","attr":{"remote":"127.0.0.1:61857","client":"conn225","negotiatedCompressors":[],"doc":{"driver":{"name":"PyMongo|Flask-PyMongo","version":"3.11.4|2.3.1"},"os":{"type":"Darwin","name":"Darwin","architecture":"x86_64","version":"14.5"},"platform":"CPython 3.10.3.final.0"}}}