### PR TITLE
Fix handling of _version.py file

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -46,9 +46,43 @@ jobs:
           name: dist-${{ github.run_id }}
           path: ./dist/*.*
 
+  test_dist:
+    name: Test Distribution Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          # Build sdist on lowest supported Python
+          python-version: '3.9'
+
+      - name: Download the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_id }}
+          path: dist/
+
+      - name: Test the sdist
+        run: |
+          cd dist
+          pip install *.tar.gz
+          python -c "import flask_pymongo"
+          pip uninstall -y flask_pymongo
+
+      - name: Test the wheel
+        run: |
+          cd dist
+          pip install *.whl
+          python -c "import flask_pymongo"
+          pip uninstall -y flask_pymongo
+
   publish:
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi
-    needs: [build_dist]
+    needs: [test_dist]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -47,6 +47,7 @@ jobs:
           path: ./dist/*.*
 
   test_dist:
+    needs: [build_dist]
     name: Test Distribution Files
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ _build
 dist/
 *.pyc
 .pytest_cache/
-_version.py
-version.txt
 .eggs/
 .tox/
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - TDB
 
+## 3.0.1 Jan 29, 2005
+
+- Fix inclusion of `_version.py` file.
+
 ## 3.0.0: Jan 29, 2025
 
 - Support Flask 3.0+ and PyMongo 4.0+.


### PR DESCRIPTION
Fixes #186.  Hatch was using the `.gitignore` file to determine which files to include in the dists.