### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - TDB
 
-## 3.0.1 Jan 29, 2005
+## 3.0.1 Jan 29, 2025
 
 - Fix inclusion of `_version.py` file.
 


### PR DESCRIPTION
Fixes a small typo in the [CHANGELOG.md](https://github.com/mongodb-labs/flask-pymongo/blob/main/CHANGELOG.md) where the year for v3.0.1 was incorrectly listed as 2005 instead of 2025